### PR TITLE
Enforce dependency min versions to avoid security vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 gem 'webrick'
+
+# To fix security vulnerabilities; see dependabot alerts
+gem "tzinfo", ">= 1.2.10"
+gem "nokogiri", ">= 1.13.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,6 +257,8 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  nokogiri (>= 1.13.6)
+  tzinfo (>= 1.2.10)
   webrick
 
 BUNDLED WITH


### PR DESCRIPTION
- Fixes [Security CVE alert #9](https://github.com/praveen-palanisamy/praveen-palanisamy.github.io/security/dependabot/9)
- Fixes [Security CVE alert #10](https://github.com/praveen-palanisamy/praveen-palanisamy.github.io/security/dependabot/10)